### PR TITLE
Add no-unused-expression and quotemark rule

### DIFF
--- a/tslint.js
+++ b/tslint.js
@@ -7,6 +7,7 @@ module.exports = {
     'max-classes-per-file': false,
     'member-access': [true, 'no-public'],
     'no-empty': [true, 'allow-empty-functions'],
+    'no-unused-expression': [true, 'allow-fast-null-checks']
     'object-literal-sort-keys': false,
     'ordered-imports': false,
     'prefer-const': false,

--- a/tslint.js
+++ b/tslint.js
@@ -11,6 +11,13 @@ module.exports = {
     'object-literal-sort-keys': false,
     'ordered-imports': false,
     'prefer-const': false,
+    'quotemark': [
+      true,
+      'single',
+      'avoid-escape',
+      'avoid-template',
+      'jsx-double'
+    ],
     'variable-name': false,
   },
 };

--- a/tslint.js
+++ b/tslint.js
@@ -1,15 +1,15 @@
 module.exports = {
   defaultSeverity: 'error',
   rules: {
-    'max-classes-per-file': false,
-    'ordered-imports': false,
-    'interface-over-type-literal': false,
-    'member-access': [true, 'no-public'],
-    'prefer-const': false,
     'array-type': [true, 'generic'],
-    'variable-name': false,
-    'object-literal-sort-keys': false,
     'interface-name': [true, 'never-prefix'],
+    'interface-over-type-literal': false,
+    'max-classes-per-file': false,
+    'member-access': [true, 'no-public'],
     'no-empty': [true, 'allow-empty-functions'],
+    'object-literal-sort-keys': false,
+    'ordered-imports': false,
+    'prefer-const': false,
+    'variable-name': false,
   },
 };


### PR DESCRIPTION
- `no-unused-expression` https://palantir.github.io/tslint/rules/no-unused-expression/
```ts
// Turning on 'allow-fast-null-checks' so we can do:
onPress && onPress()

// Instead of
if (onPress) {
  onPress()
}
```
- `quotemark` https://palantir.github.io/tslint/rules/quotemark/
```jsx
// Enforce single quote
let text = "foo" // Error!
let anotherText = 'bar' // Safe

// Avoid escape
let text = "Let's TypeScript!" // Safe, even when enforcing single quote

// Avoid template
let text = `Look ma, no interpolation` // Error!
let text2 = `${one}%` // Safe

// Enforce double on JSX attributes
<Header title='beep' /> // Error!

<Header title="bop" /> // Safe

<Header title={'bleh'} /> // Safe? But let's not do this.

```